### PR TITLE
Fix for date not updating after running auto-advance

### DIFF
--- a/src/SignUpSheetAdvance.js
+++ b/src/SignUpSheetAdvance.js
@@ -138,9 +138,10 @@ function updateDate(signUpSheet, signUpTemplate) {
     .getValue();
 
   var date = new Date(prevDate);
-  console.log("new date", date);
   date.setDate(date.getDate() + 7);
 
   dateCell.setValue(date);
-  console.log("date cell", dateCell);
+  // Note: we need to flush to be sure all pending spreadsheet operations
+  //  complete before the script exits
+  SpreadsheetApp.flush();
 }

--- a/src/SignUpSheetAdvance.js
+++ b/src/SignUpSheetAdvance.js
@@ -138,7 +138,9 @@ function updateDate(signUpSheet, signUpTemplate) {
     .getValue();
 
   var date = new Date(prevDate);
+  console.log("new date", date);
   date.setDate(date.getDate() + 7);
 
   dateCell.setValue(date);
+  console.log("date cell", dateCell);
 }

--- a/src/sheetnames.js
+++ b/src/sheetnames.js
@@ -7,15 +7,20 @@
  */
 
 // Production Sheet Names
-const SIGNUP_SHEET_NAME = "Sign-up Sheet";
-const TM_DETAILS_SHEET_NAME = "ToastmasterDetails";
-const ROLES_SHEET_NAME = "Roles";
+// const SIGNUP_SHEET_NAME = "Sign-up Sheet";
+// const TM_DETAILS_SHEET_NAME = "ToastmasterDetails";
+// const ROLES_SHEET_NAME = "Roles";
 const ROSTER_SHEET_NAME = "Roster";
 const SIGNUP_TEMPLATE = "SignUp Template";
 
-// Uncomment to switch to testing copies of sheets
-// const SIGNUP_SHEET_NAME = "Copy of Sign-up Sheet";
-// const TM_DETAILS_SHEET_NAME = "Copy of ToastmasterDetails";
-// const ROLES_SHEET_NAME = "Copy of Roles";
+// TODO(bshaibu): revert after testing is over
+// Uncomment to switch to testing copies of sheets. 
+//  Comment out any sheets you're planning to test on.
+//  You will need to "Duplicate" the sheets in the actual spreadsheet first.
+//  Note: you generally only need copy and change
+//      SIGNUP_SHEET_NAME, TM_DETAILS_SHEET_NAME, and ROLES_SHEET_NAME
+const SIGNUP_SHEET_NAME = "Copy of Sign-up Sheet";
+const TM_DETAILS_SHEET_NAME = "Copy of ToastmasterDetails";
+const ROLES_SHEET_NAME = "Copy of Roles";
 // const ROSTER_SHEET_NAME = "Copy of Roster";
 // const SIGNUP_TEMPLATE = "Copy of SignUp Template";

--- a/src/sheetnames.js
+++ b/src/sheetnames.js
@@ -7,20 +7,19 @@
  */
 
 // Production Sheet Names
-// const SIGNUP_SHEET_NAME = "Sign-up Sheet";
-// const TM_DETAILS_SHEET_NAME = "ToastmasterDetails";
-// const ROLES_SHEET_NAME = "Roles";
+const SIGNUP_SHEET_NAME = "Sign-up Sheet";
+const TM_DETAILS_SHEET_NAME = "ToastmasterDetails";
+const ROLES_SHEET_NAME = "Roles";
 const ROSTER_SHEET_NAME = "Roster";
 const SIGNUP_TEMPLATE = "SignUp Template";
 
-// TODO(bshaibu): revert after testing is over
 // Uncomment to switch to testing copies of sheets. 
 //  Comment out any sheets you're planning to test on.
 //  You will need to "Duplicate" the sheets in the actual spreadsheet first.
 //  Note: you generally only need copy and change
 //      SIGNUP_SHEET_NAME, TM_DETAILS_SHEET_NAME, and ROLES_SHEET_NAME
-const SIGNUP_SHEET_NAME = "Copy of Sign-up Sheet";
-const TM_DETAILS_SHEET_NAME = "Copy of ToastmasterDetails";
-const ROLES_SHEET_NAME = "Copy of Roles";
+// const SIGNUP_SHEET_NAME = "Copy of Sign-up Sheet";
+// const TM_DETAILS_SHEET_NAME = "Copy of ToastmasterDetails";
+// const ROLES_SHEET_NAME = "Copy of Roles";
 // const ROSTER_SHEET_NAME = "Copy of Roster";
 // const SIGNUP_TEMPLATE = "Copy of SignUp Template";


### PR DESCRIPTION
A fix for a bug I seemed to have introduced where the Auto-Advance doesn't add a date to the newly added block of sign-ups.

The issue was caused by operations not flushing after cell value updated. (I noticed because adding console.log fixed the issue)
- https://stackoverflow.com/questions/31659186/how-to-refresh-a-sheets-cell-value-in-google-apps-script
- https://developers.google.com/apps-script/reference/spreadsheet/spreadsheet-app#flush

Depends on #13 merging first

Note: This actually is already deployed