### PR TITLE
Automatically protect new rows on spreadsheet advance

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,4 @@ For now, if you want to test changes on sheets, you are advised to:
         npm run push
     ```
 13. Verify things work as expected.
+14. Delete the Copy sheets you made!

--- a/src/CopySignUpSheetToRoles.js
+++ b/src/CopySignUpSheetToRoles.js
@@ -173,6 +173,11 @@ function getSignUpSheetData() {
     .getValues();
 }
 
+/**
+ * Copies all details from the active (leftmost) sign up sheet entry
+ *  into the Roles spreadsheet.
+ * @returns roleEntryRow the number of the row that has been added/edited
+ */
 function copyCurrentSignUpSheetEntryToRolesSheet() {
   const signUpDetails = new SignUpDetails();
   const rolesSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(
@@ -183,4 +188,5 @@ function copyCurrentSignUpSheetEntryToRolesSheet() {
   );
   signUpDetails.populateRolesSheet(rolesSheet, roleEntryRow);
   copyOfficersToRoles(prettyFormatDate(signUpDetails.date));
+  return roleEntryRow;
 }

--- a/src/CopyToastmasterDetailsToRoles.js
+++ b/src/CopyToastmasterDetailsToRoles.js
@@ -147,6 +147,10 @@ function getToastmastersDetailsSheetData() {
     .getValues();
 }
 
+/**
+ * Copies all details from the ToastmasterDetails page into the Roles spreadsheet.
+ * @returns roleEntryRow the number of the row that has been added/edited
+ */
 function copyToastmasterDetailsToRoles() {
   const tmDetails = new ToastmasterDetails();
   const rolesSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(
@@ -157,6 +161,7 @@ function copyToastmasterDetailsToRoles() {
   );
   tmDetails.populateRolesSheet(rolesSheet, roleEntryRow);
   copyOfficersToRoles(prettyFormatDate(tmDetails.date));
+  return roleEntryRow;
 }
 
 // Function to clear the roster selections

--- a/src/Main.js
+++ b/src/Main.js
@@ -1,8 +1,15 @@
 /// entrypoint script
 
+/**
+ * Runs scripts to copy latest signup sheet and toastmaster
+ *  details into Roles
+ * @returns updatedRow The row where all sign up 
+ *  details have been copied into
+ */
 function copyAllSignUpDetails() {
-  copyCurrentSignUpSheetEntryToRolesSheet();
+  const updatedRow = copyCurrentSignUpSheetEntryToRolesSheet();
   copyToastmasterDetailsToRoles();
+  return updatedRow;
 }
 
 function copyAndGenerateAgenda() {
@@ -36,7 +43,8 @@ function confirm(confirm_cb) {
 
 function clearAndAdvanceSignUp() {
   confirm(() => {
-    copyAllSignUpDetails();
+    const updatedRowNumber = copyAllSignUpDetails();
+    protectRolesSheetRow(updatedRowNumber);
     clearToastmasterDetails();
     advanceSignUpSheet();
     resetToastmasterDetailsFormulas();

--- a/src/PopulateRolesSheet.js
+++ b/src/PopulateRolesSheet.js
@@ -151,7 +151,7 @@ function getOrCreateRoleEntryRow(dateString) {
   return rowIndex;
 }
 
-// Section forn protecting the Roles spreadsheet
+// Section for protecting the Roles spreadsheet
 
 // These are the people generally allowed to edit protected sheets - Officers
 const DEFAULT_PROTECTED_RANGE_EDITORS = [
@@ -173,15 +173,15 @@ function removeAllCurrentEditors(protection) {
 }
 
 function protectRolesSheetRow(rowNumber) {
-  var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(
+  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(
     ROLES_SHEET_NAME
   );
-  var range = sheet.getRange(`${rowNumber}:${rowNumber}`);
-  var protection = range.protect().setDescription(`${PROTECTION_MESSAGE} - Row ${rowNumber}`);
+  const range = sheet.getRange(`${rowNumber}:${rowNumber}`);
+  const protection = range.protect().setDescription(`${PROTECTION_MESSAGE} - Row ${rowNumber}`);
   
   // Ensure the current user is an editor before removing others. Otherwise, if the user's edit
   // permission comes from a group, the script throws an exception upon removing the group.
-  var me = Session.getEffectiveUser();
+  const me = Session.getEffectiveUser();
   protection.addEditor(me);
 
   // Before protections can be added, exitsting user list must be removed

--- a/src/PopulateRolesSheet.js
+++ b/src/PopulateRolesSheet.js
@@ -150,3 +150,49 @@ function getOrCreateRoleEntryRow(dateString) {
 
   return rowIndex;
 }
+
+// Section forn protecting the Roles spreadsheet
+
+// These are the people generally allowed to edit protected sheets - Officers
+const DEFAULT_PROTECTED_RANGE_EDITORS = [
+  // Allow MVTM Officers
+  "mountainviewtoastmastersofficers@googlegroups.com",
+  // Allow Craig Wood (he's the spreadsheet owner and probably already added)
+  "cwwood1234@gmail.com",
+  // Allow the Officer's "robot" account
+  "mountainviewtm@gmail.com"
+];
+const PROTECTION_MESSAGE = "Don't allow editing of finalized roles sheet rows (saved sign up details) by non-officers";
+
+
+function removeAllCurrentEditors(protection) {
+  
+  if (protection.canDomainEdit()) {
+    protection.setDomainEdit(false);
+  }
+}
+
+function protectRolesSheetRow(rowNumber) {
+  var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(
+    ROLES_SHEET_NAME
+  );
+  var range = sheet.getRange(`${rowNumber}:${rowNumber}`);
+  var protection = range.protect().setDescription(`${PROTECTION_MESSAGE} - Row ${rowNumber}`);
+  
+  // Ensure the current user is an editor before removing others. Otherwise, if the user's edit
+  // permission comes from a group, the script throws an exception upon removing the group.
+  var me = Session.getEffectiveUser();
+  protection.addEditor(me);
+
+  // Before protections can be added, exitsting user list must be removed
+  protection.removeEditors(protection.getEditors());
+
+  // Add the default editors
+  protection.addEditors(DEFAULT_PROTECTED_RANGE_EDITORS);
+
+  // Restrict editing to only users explicitly set as editors - not just anyone
+  //  with permissions to the sheet
+  if (protection.canDomainEdit()) {
+    protection.setDomainEdit(false);
+  }
+}

--- a/src/PopulateRolesSheet.js
+++ b/src/PopulateRolesSheet.js
@@ -160,13 +160,12 @@ const DEFAULT_PROTECTED_RANGE_EDITORS = [
   // Allow Craig Wood (he's the spreadsheet owner and probably already added)
   "cwwood1234@gmail.com",
   // Allow the Officer's "robot" account
-  "mountainviewtm@gmail.com"
+  "mountainviewtm@gmail.com",
 ];
-const PROTECTION_MESSAGE = "Don't allow editing of finalized roles sheet rows (saved sign up details) by non-officers";
-
+const PROTECTION_MESSAGE =
+  "Don't allow editing of finalized roles sheet rows (saved sign up details) by non-officers";
 
 function removeAllCurrentEditors(protection) {
-  
   if (protection.canDomainEdit()) {
     protection.setDomainEdit(false);
   }
@@ -177,8 +176,10 @@ function protectRolesSheetRow(rowNumber) {
     ROLES_SHEET_NAME
   );
   const range = sheet.getRange(`${rowNumber}:${rowNumber}`);
-  const protection = range.protect().setDescription(`${PROTECTION_MESSAGE} - Row ${rowNumber}`);
-  
+  const protection = range
+    .protect()
+    .setDescription(`${PROTECTION_MESSAGE} - Row ${rowNumber}`);
+
   // Ensure the current user is an editor before removing others. Otherwise, if the user's edit
   // permission comes from a group, the script throws an exception upon removing the group.
   const me = Session.getEffectiveUser();

--- a/src/sheetnames.js
+++ b/src/sheetnames.js
@@ -7,20 +7,19 @@
  */
 
 // Production Sheet Names
-// const SIGNUP_SHEET_NAME = "Sign-up Sheet";
-// const TM_DETAILS_SHEET_NAME = "ToastmasterDetails";
-// const ROLES_SHEET_NAME = "Roles";
+const SIGNUP_SHEET_NAME = "Sign-up Sheet";
+const TM_DETAILS_SHEET_NAME = "ToastmasterDetails";
+const ROLES_SHEET_NAME = "Roles";
 const ROSTER_SHEET_NAME = "Roster";
 const SIGNUP_TEMPLATE = "SignUp Template";
 
-// TODO(bshaibu): revert when done
 // Uncomment to switch to testing copies of sheets. 
 //  Comment out any sheets you're planning to test on.
 //  You will need to "Duplicate" the sheets in the actual spreadsheet first.
 //  Note: you generally only need copy and change
 //      SIGNUP_SHEET_NAME, TM_DETAILS_SHEET_NAME, and ROLES_SHEET_NAME
-const SIGNUP_SHEET_NAME = "Copy of Sign-up Sheet";
-const TM_DETAILS_SHEET_NAME = "Copy of ToastmasterDetails";
-const ROLES_SHEET_NAME = "Copy of Roles";
+// const SIGNUP_SHEET_NAME = "Copy of Sign-up Sheet";
+// const TM_DETAILS_SHEET_NAME = "Copy of ToastmasterDetails";
+// const ROLES_SHEET_NAME = "Copy of Roles";
 // const ROSTER_SHEET_NAME = "Copy of Roster";
 // const SIGNUP_TEMPLATE = "Copy of SignUp Template";

--- a/src/sheetnames.js
+++ b/src/sheetnames.js
@@ -7,19 +7,20 @@
  */
 
 // Production Sheet Names
-const SIGNUP_SHEET_NAME = "Sign-up Sheet";
-const TM_DETAILS_SHEET_NAME = "ToastmasterDetails";
-const ROLES_SHEET_NAME = "Roles";
+// const SIGNUP_SHEET_NAME = "Sign-up Sheet";
+// const TM_DETAILS_SHEET_NAME = "ToastmasterDetails";
+// const ROLES_SHEET_NAME = "Roles";
 const ROSTER_SHEET_NAME = "Roster";
 const SIGNUP_TEMPLATE = "SignUp Template";
 
+// TODO(bshaibu): revert when done
 // Uncomment to switch to testing copies of sheets. 
 //  Comment out any sheets you're planning to test on.
 //  You will need to "Duplicate" the sheets in the actual spreadsheet first.
 //  Note: you generally only need copy and change
 //      SIGNUP_SHEET_NAME, TM_DETAILS_SHEET_NAME, and ROLES_SHEET_NAME
-// const SIGNUP_SHEET_NAME = "Copy of Sign-up Sheet";
-// const TM_DETAILS_SHEET_NAME = "Copy of ToastmasterDetails";
-// const ROLES_SHEET_NAME = "Copy of Roles";
+const SIGNUP_SHEET_NAME = "Copy of Sign-up Sheet";
+const TM_DETAILS_SHEET_NAME = "Copy of ToastmasterDetails";
+const ROLES_SHEET_NAME = "Copy of Roles";
 // const ROSTER_SHEET_NAME = "Copy of Roster";
 // const SIGNUP_TEMPLATE = "Copy of SignUp Template";


### PR DESCRIPTION
Fixes https://github.com/Mountain-View-Toastmasters/sign-up-sheet/issues/12

Automatically add a protection range that only includes officers, Craig (sheet owner), the MVTM robot account, and the role updater in those allowed to modify a "published" roles row.

E.g. of created protections
<img width="1085" alt="Screen Shot 2021-05-16 at 10 09 05 PM" src="https://user-images.githubusercontent.com/2855159/118436152-214cdd80-b695-11eb-886f-d052db3ab717.png">

Depends on https://github.com/Mountain-View-Toastmasters/sign-up-sheet/pull/14 merging first

Note: This actually is already deployed