### PR TITLE
Update scripts to use relative position of details page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sign-up-sheet",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "App scripts for the MVTM sign-up sheet",
   "main": "index.js",
   "scripts": {

--- a/src/CopySignUpSheetToRoles.js
+++ b/src/CopySignUpSheetToRoles.js
@@ -9,8 +9,8 @@
 // The indices of the cells that the current entry in
 //    the sign up sheet relies on.
 //  (1-indexed relative to spreadsheet)
-const SIGNUP_START_ROW = 7;
-const SIGNUP_END_ROW = 27;
+const SIGNUP_START_ROW = 2;
+const SIGNUP_END_ROW = 22;
 const SIGNUP_START_COL = 2;
 const SIGNUP_END_COL = 9;
 

--- a/src/CopyToastmasterDetailsToRoles.js
+++ b/src/CopyToastmasterDetailsToRoles.js
@@ -182,12 +182,15 @@ function resetToastmasterDetailsFormulas() {
 
   // Set Date cell
   var currentDateCell = toastmasterDetails.getRange("B1");
-  currentDateCell.setFormula(`='${SIGNUP_SHEET_NAME}'!C7`);
+  // NOTE(acmiyaguchi): variables are generally defined in
+  // CopySignUpSheetToRoles, but I don't appreciate the design choice of gs to
+  // share variable scope across files. It's very confusing.
+  currentDateCell.setFormula(`='${SIGNUP_SHEET_NAME}'!C${SIGNUP_START_ROW}`);
 
   // Set Speaker 1 - 3 shared details
-  setSpeakerCells(toastmasterDetails, 8, 20);
-  setSpeakerCells(toastmasterDetails, 9, 21);
-  setSpeakerCells(toastmasterDetails, 10, 22);
+  setSpeakerCells(toastmasterDetails, 8, SIGNUP_START_ROW + SPK1_ROW_IDX);
+  setSpeakerCells(toastmasterDetails, 9, SIGNUP_START_ROW + SPK2_ROW_IDX);
+  setSpeakerCells(toastmasterDetails, 10, SIGNUP_START_ROW + SPK3_ROW_IDX);
 }
 
 function setSpeakerCells(toastmasterDetails, tmDetailsRow, signUpSheetRow) {

--- a/src/Main.js
+++ b/src/Main.js
@@ -3,7 +3,7 @@
 /**
  * Runs scripts to copy latest signup sheet and toastmaster
  *  details into Roles
- * @returns updatedRow The row where all sign up 
+ * @returns updatedRow The row where all sign up
  *  details have been copied into
  */
 function copyAllSignUpDetails() {
@@ -62,6 +62,10 @@ function onOpen() {
         .createMenu("Officers Only")
         // ensure items in this submenu have a confirmation prompt
         .addItem("Advance Sign Up Sheet", "clearAndAdvanceSignUp")
+        .addItem(
+          "Reset Toastmasters Details",
+          "resetToastmasterDetailsFormulas"
+        )
     )
     .addToUi();
 }


### PR DESCRIPTION
The sign-up sheet broke when extra information about speeches moved from the top of the sheet to the bottom. This patch has been long in the waiting, but it was completely broken last meeting. I deployed this, and it seems to be working

I also added an option to the UI to be able to manually reset the details page.