### PR TITLE
Hybrid meeting updates to include remote status and tech chair

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sign-up-sheet",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sign-up-sheet",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "App scripts for the MVTM sign-up sheet",
   "main": "index.js",
   "scripts": {

--- a/src/CopySignUpSheetToRoles.js
+++ b/src/CopySignUpSheetToRoles.js
@@ -136,39 +136,57 @@ class SignUpDetails {
     };
 
     // Fill out meeting metadata (minus already filled-in date)
-    setCell(Meeting_Location_COL, this.meetingLocation);
+    setCell(ROLES_COL_MAP["Meeting_Location"], this.meetingLocation);
 
     // Fill out Functionaries
-    setCell(Sergeant_at_Arms_COL, this.sergeantAtArms);
-    setCell(Secretary_COL, this.secretary);
-    setCell(Toastmaster_COL, this.toastmaster);
-    setCell(Jokemaster_COL, this.jokemaster);
-    setCell(General_Evaluator_COL, this.generalEvaluator);
-    setCell(Recorder_COL, this.recorder);
-    setCell(Timer_COL, this.timer);
-    setCell(Ah_Counter_COL, this.ahCounter);
-    setCell(Wordmaster_Grammarian_COL, this.wordmasterGrammarian);
-    setCell(Table_Topics_Master_COL, this.tableTopicsMaster);
+    setCell(ROLES_COL_MAP["Sergeant_at_Arms"], this.sergeantAtArms);
+    setCell(ROLES_COL_MAP["Secretary"], this.secretary);
+    setCell(ROLES_COL_MAP["Toastmaster"], this.toastmaster);
+    setCell(ROLES_COL_MAP["Jokemaster"], this.jokemaster);
+    setCell(ROLES_COL_MAP["General_Evaluator"], this.generalEvaluator);
+    setCell(ROLES_COL_MAP["Recorder"], this.recorder);
+    setCell(ROLES_COL_MAP["Timer"], this.timer);
+    setCell(ROLES_COL_MAP["Ah_Counter"], this.ahCounter);
+    setCell(ROLES_COL_MAP["Wordmaster_Grammarian"], this.wordmasterGrammarian);
+    setCell(ROLES_COL_MAP["Table_Topics_Master"], this.tableTopicsMaster);
 
     // Fill out Speakers
     this._populateSpeakerCells(rolesSheet, roleEntryRow);
 
     // Fill out Evaluators
-    setCell(Evaluator_1_COL, this.evaluator1);
-    setCell(Evaluator_2_COL, this.evaluator2);
-    setCell(Evaluator_3_COL, this.evaluator3);
+    setCell(ROLES_COL_MAP["Evaluator_1"], this.evaluator1);
+    setCell(ROLES_COL_MAP["Evaluator_2"], this.evaluator2);
+    setCell(ROLES_COL_MAP["Evaluator_3"], this.evaluator3);
     // TODO(bshaibu): We might want to handle adding a 4th and 5th evaluator to the sign up sheet
 
     // Fill out Waiting list speakers
-    setCell(Waiting_List_Speaker_1_COL, this.waitlistSpeaker1.name);
-    setCell(Waiting_List_Speaker_2_COL, this.waitlistSpeaker2.name);
+    setCell(
+      ROLES_COL_MAP["Waiting_List_Speaker_1"],
+      this.waitlistSpeaker1.name
+    );
+    setCell(
+      ROLES_COL_MAP["Waiting_List_Speaker_2"],
+      this.waitlistSpeaker2.name
+    );
     // TODO(bshaibu): Do we want to save anything beside the waiting list speaker's name?
   }
 
   _populateSpeakerCells(rolesSheet, roleEntryRow) {
-    this.speaker1.populateRolesSheet(rolesSheet, roleEntryRow, Speaker_1_COL);
-    this.speaker2.populateRolesSheet(rolesSheet, roleEntryRow, Speaker_2_COL);
-    this.speaker3.populateRolesSheet(rolesSheet, roleEntryRow, Speaker_3_COL);
+    this.speaker1.populateRolesSheet(
+      rolesSheet,
+      roleEntryRow,
+      ROLES_COL_MAP["Speaker_1"]
+    );
+    this.speaker2.populateRolesSheet(
+      rolesSheet,
+      roleEntryRow,
+      ROLES_COL_MAP["Speaker_2"]
+    );
+    this.speaker3.populateRolesSheet(
+      rolesSheet,
+      roleEntryRow,
+      ROLES_COL_MAP["Speaker_3"]
+    );
     // TODO(bshaibu): We might want to handle adding a 4th and 5th speaker to the sign up sheet
   }
 }

--- a/src/CopySignUpSheetToRoles.js
+++ b/src/CopySignUpSheetToRoles.js
@@ -12,23 +12,22 @@
 const SIGNUP_START_ROW = 2;
 const SIGNUP_END_ROW = 22;
 const SIGNUP_START_COL = 2;
-const SIGNUP_END_COL = 9;
+const SIGNUP_END_COL = 7;
 
 // Sign Up Sheet Field References
 // These are relative to the current entry in the
 //    sign up sheet and NOT the entire spreadsheet
 //    (0-indexed)
-var DATE_COL_IDX = 1;
-var MEETING_LOCATION_COL_IDX = 2;
+const SIGNUP_DATE_COL_IDX = 2;
+const SIGNUP_MEETING_LOCATION_COL_IDX = 3;
 
 // Sign Up Sheet Headers
 //  (relative to current entry, 0-indexed)
 const SIGNUP_HEADER_NAMES = [
   "confirmed",
+  "location",
   "role",
   "name",
-  "fullName",
-  "email",
   "pathway",
   "level",
   "project",
@@ -72,7 +71,7 @@ const SIGNUP_ROW_MAP = Object.fromEntries(
 class SpeechDetails {
   constructor(signupsData, rowIdx) {
     const speakerRow = signupsData[rowIdx];
-    for (let [name, index] of SIGNUP_HEADER_MAP.entries()) {
+    for (let [name, index] of Object.entries(SIGNUP_HEADER_MAP)) {
       this[name] = speakerRow[index];
     }
   }
@@ -108,9 +107,12 @@ class SignUpDetails {
   constructor() {
     const signupsData = getSignUpSheetData();
 
-    this.date = signupsData[SIGNUP_ROW_MAP["meetingHeader"]][DATE_COL_IDX];
+    this.date =
+      signupsData[SIGNUP_ROW_MAP["meetingHeader"]][SIGNUP_DATE_COL_IDX];
     this.meetingLocation =
-      signupsData[SIGNUP_ROW_MAP["meetingHeader"]][MEETING_LOCATION_COL_IDX];
+      signupsData[SIGNUP_ROW_MAP["meetingHeader"]][
+        SIGNUP_MEETING_LOCATION_COL_IDX
+      ];
 
     // helper function to keep things compact
     let rows_between = (start, end) => between(SIGNUP_ROW_NAMES, start, end);
@@ -118,7 +120,7 @@ class SignUpDetails {
     for (let name of rows_between("sergeantAtArms", "tableTopicsMaster").concat(
       rows_between("evaluator1", "evaluator3")
     )) {
-      this[name] = signupsData[SIGNUP_ROW_MAP[name]][NAME_COL_IDX];
+      this[name] = signupsData[SIGNUP_ROW_MAP[name]][SIGNUP_HEADER_MAP["name"]];
     }
     for (let name of rows_between("speaker1", "speaker3").concat(
       rows_between("waitlistSpeaker1", "waitlistSpeaker2")

--- a/src/CopySignUpSheetToRoles.js
+++ b/src/CopySignUpSheetToRoles.js
@@ -141,6 +141,7 @@ class SignUpDetails {
     // Fill out Functionaries
     setCell(ROLES_COL_MAP["Sergeant_at_Arms"], this.sergeantAtArms);
     setCell(ROLES_COL_MAP["Secretary"], this.secretary);
+    setCell(ROLES_COL_MAP["Tech_Chair"], this.techChair);
     setCell(ROLES_COL_MAP["Toastmaster"], this.toastmaster);
     setCell(ROLES_COL_MAP["Jokemaster"], this.jokemaster);
     setCell(ROLES_COL_MAP["General_Evaluator"], this.generalEvaluator);

--- a/src/CopySignUpSheetToRoles.js
+++ b/src/CopySignUpSheetToRoles.js
@@ -93,17 +93,6 @@ class SpeechDetails {
   }
 }
 
-/// Slice a list based on the location of two entries in the list inclusive.
-/// Throws an exception if the resulting slice is empty. Assumes all entires are
-/// unique.
-function between(arr, first, last) {
-  let sliced = arr.slice(arr.indexOf(first), arr.indexOf(last) + 1);
-  if (sliced.length == 0) {
-    throw "sliced list is empty";
-  }
-  return sliced;
-}
-
 class SignUpDetails {
   constructor() {
     const signupsData = getSignUpSheetData();
@@ -116,15 +105,19 @@ class SignUpDetails {
       ];
 
     // helper function to keep things compact
-    let rows_between = (start, end) => between(SIGNUP_ROW_NAMES, start, end);
+    let rowsBetween = (start, end) =>
+      sliceRowsBetweenValues(SIGNUP_ROW_NAMES, start, end);
 
-    for (let name of rows_between("sergeantAtArms", "tableTopicsMaster").concat(
-      rows_between("evaluator1", "evaluator3")
+    // Add general roles to to signup details
+    for (let name of rowsBetween("sergeantAtArms", "tableTopicsMaster").concat(
+      rowsBetween("evaluator1", "evaluator3")
     )) {
       this[name] = signupsData[SIGNUP_ROW_MAP[name]][SIGNUP_HEADER_MAP["name"]];
     }
-    for (let name of rows_between("speaker1", "speaker3").concat(
-      rows_between("waitlistSpeaker1", "waitlistSpeaker2")
+
+    // Add Speaker information to signup details
+    for (let name of rowsBetween("speaker1", "speaker3").concat(
+      rowsBetween("waitlistSpeaker1", "waitlistSpeaker2")
     )) {
       this[name] = new SpeechDetails(signupsData, SIGNUP_ROW_MAP[name]);
     }

--- a/src/CopySignUpSheetToRoles.js
+++ b/src/CopySignUpSheetToRoles.js
@@ -23,14 +23,19 @@ var MEETING_LOCATION_COL_IDX = 2;
 
 // Sign Up Sheet Headers
 //  (relative to current entry, 0-indexed)
-var CONFIRM_COL_IDX = 0;
-var ROLE_COL_IDX = 1;
-var NAME_COL_IDX = 2;
-var FULLNAME_COL_IDX = 3;
-var EMAIL_COL_IDX = 4;
-var PATHWAY_COL_IDX = 5;
-var LEVEL_COL_IDX = 6;
-var PROJECT_COL_IDX = 7;
+const SIGNUP_HEADER_NAMES = [
+  "confirmed",
+  "role",
+  "name",
+  "fullName",
+  "email",
+  "pathway",
+  "level",
+  "project",
+];
+const SIGNUP_HEADER_MAP = Object.fromEntries(
+  SIGNUP_HEADER_NAMES.map((name, index) => [name, index])
+);
 
 // Sign Up Sheet Rows
 // By naming each row in the spreadsheet, it should be relatively simple to add
@@ -67,14 +72,9 @@ const SIGNUP_ROW_MAP = Object.fromEntries(
 class SpeechDetails {
   constructor(signupsData, rowIdx) {
     const speakerRow = signupsData[rowIdx];
-    this.confirmed = speakerRow[CONFIRM_COL_IDX];
-    this.role = speakerRow[ROLE_COL_IDX];
-    this.name = speakerRow[NAME_COL_IDX];
-    this.fullName = speakerRow[FULLNAME_COL_IDX];
-    this.email = speakerRow[EMAIL_COL_IDX];
-    this.pathway = speakerRow[PATHWAY_COL_IDX];
-    this.level = speakerRow[LEVEL_COL_IDX];
-    this.project = speakerRow[PROJECT_COL_IDX];
+    for (let [name, index] of SIGNUP_HEADER_MAP.entries()) {
+      this[name] = speakerRow[index];
+    }
   }
 
   populateRolesSheet(rolesSheet, roleEntryRow, speakerCol) {

--- a/src/CopySignUpSheetToRoles.js
+++ b/src/CopySignUpSheetToRoles.js
@@ -10,7 +10,7 @@
 //    the sign up sheet relies on.
 //  (1-indexed relative to spreadsheet)
 const SIGNUP_START_ROW = 2;
-const SIGNUP_END_ROW = 22;
+const SIGNUP_END_ROW = 23;
 const SIGNUP_START_COL = 2;
 const SIGNUP_END_COL = 7;
 
@@ -45,6 +45,7 @@ const SIGNUP_ROW_NAMES = [
   "signUpHeader",
   "sergeantAtArms",
   "secretary",
+  "techChair",
   "toastmaster",
   "jokemaster",
   "generalEvaluator",

--- a/src/CopySignUpSheetToRoles.js
+++ b/src/CopySignUpSheetToRoles.js
@@ -36,7 +36,7 @@ var PROJECT_COL_IDX = 7;
 // By naming each row in the spreadsheet, it should be relatively simple to add
 // or remove rows without having explicitly enumerate their indices. This is
 // 0-offset from the start location of the rows.
-const ROW_NAMES = [
+const SIGNUP_ROW_NAMES = [
   "meetingHeader",
   "signUpHeader",
   "sergeantAtArms",
@@ -59,8 +59,8 @@ const ROW_NAMES = [
   "waitlistSpeaker1",
   "waitlistSpeaker2",
 ];
-const ROW_MAPPING = Object.fromEntries(
-  ROW_NAMES.map((name, index) => [name, index])
+const SIGNUP_ROW_MAP = Object.fromEntries(
+  SIGNUP_ROW_NAMES.map((name, index) => [name, index])
 );
 
 // Helpers and Classes
@@ -108,22 +108,22 @@ class SignUpDetails {
   constructor() {
     const signupsData = getSignUpSheetData();
 
-    this.date = signupsData[ROW_MAPPING["meetingHeader"]][DATE_COL_IDX];
+    this.date = signupsData[SIGNUP_ROW_MAP["meetingHeader"]][DATE_COL_IDX];
     this.meetingLocation =
-      signupsData[ROW_MAPPING["meetingHeader"]][MEETING_LOCATION_COL_IDX];
+      signupsData[SIGNUP_ROW_MAP["meetingHeader"]][MEETING_LOCATION_COL_IDX];
 
     // helper function to keep things compact
-    let rows_between = (start, end) => between(ROW_NAMES, start, end);
+    let rows_between = (start, end) => between(SIGNUP_ROW_NAMES, start, end);
 
     for (let name of rows_between("sergeantAtArms", "tableTopicsMaster").concat(
       rows_between("evaluator1", "evaluator3")
     )) {
-      this[name] = signupsData[ROW_MAPPING[name]][NAME_COL_IDX];
+      this[name] = signupsData[SIGNUP_ROW_MAP[name]][NAME_COL_IDX];
     }
     for (let name of rows_between("speaker1", "speaker3").concat(
       rows_between("waitlistSpeaker1", "waitlistSpeaker2")
     )) {
-      this[name] = new SpeechDetails(signupsData, ROW_MAPPING[name]);
+      this[name] = new SpeechDetails(signupsData, SIGNUP_ROW_MAP[name]);
     }
   }
 

--- a/src/CopyToastmasterDetailsToRoles.js
+++ b/src/CopyToastmasterDetailsToRoles.js
@@ -191,17 +191,17 @@ function resetToastmasterDetailsFormulas() {
   setSpeakerCells(
     toastmasterDetails,
     8,
-    SIGNUP_START_ROW + ROW_MAPPING["speaker1"]
+    SIGNUP_START_ROW + SIGNUP_ROW_MAP["speaker1"]
   );
   setSpeakerCells(
     toastmasterDetails,
     9,
-    SIGNUP_START_ROW + ROW_MAPPING["speaker2"]
+    SIGNUP_START_ROW + SIGNUP_ROW_MAP["speaker2"]
   );
   setSpeakerCells(
     toastmasterDetails,
     10,
-    SIGNUP_START_ROW + ROW_MAPPING["speaker3"]
+    SIGNUP_START_ROW + SIGNUP_ROW_MAP["speaker3"]
   );
 }
 

--- a/src/CopyToastmasterDetailsToRoles.js
+++ b/src/CopyToastmasterDetailsToRoles.js
@@ -185,7 +185,9 @@ function resetToastmasterDetailsFormulas() {
   // NOTE(acmiyaguchi): variables are generally defined in
   // CopySignUpSheetToRoles, but I don't appreciate the design choice of gs to
   // share variable scope across files. It's very confusing.
-  currentDateCell.setFormula(`='${SIGNUP_SHEET_NAME}'!C${SIGNUP_START_ROW}`);
+  // Also, it may be useful to make this an integer offset from the start of the
+  // sheet at some point.
+  currentDateCell.setFormula(`='${SIGNUP_SHEET_NAME}'!D${SIGNUP_START_ROW}`);
 
   // Set Speaker 1 - 3 shared details
   setSpeakerCells(
@@ -211,8 +213,9 @@ function setSpeakerCells(toastmasterDetails, tmDetailsRow, signUpSheetRow) {
   var levelCell = toastmasterDetails.getRange(`D${tmDetailsRow}`);
   var projectCell = toastmasterDetails.getRange(`E${tmDetailsRow}`);
 
-  speakerCell.setFormula(`='${SIGNUP_SHEET_NAME}'!D${signUpSheetRow}`);
-  pathNameCell.setFormula(`='${SIGNUP_SHEET_NAME}'!G${signUpSheetRow}`);
-  levelCell.setFormula(`='${SIGNUP_SHEET_NAME}'!H${signUpSheetRow}`);
-  projectCell.setFormula(`='${SIGNUP_SHEET_NAME}'!I${signUpSheetRow}`);
+  // NOTE: these must be manually updated if the columns change at all
+  speakerCell.setFormula(`='${SIGNUP_SHEET_NAME}'!E${signUpSheetRow}`);
+  pathNameCell.setFormula(`='${SIGNUP_SHEET_NAME}'!F${signUpSheetRow}`);
+  levelCell.setFormula(`='${SIGNUP_SHEET_NAME}'!G${signUpSheetRow}`);
+  projectCell.setFormula(`='${SIGNUP_SHEET_NAME}'!H${signUpSheetRow}`);
 }

--- a/src/CopyToastmasterDetailsToRoles.js
+++ b/src/CopyToastmasterDetailsToRoles.js
@@ -188,9 +188,21 @@ function resetToastmasterDetailsFormulas() {
   currentDateCell.setFormula(`='${SIGNUP_SHEET_NAME}'!C${SIGNUP_START_ROW}`);
 
   // Set Speaker 1 - 3 shared details
-  setSpeakerCells(toastmasterDetails, 8, SIGNUP_START_ROW + SPK1_ROW_IDX);
-  setSpeakerCells(toastmasterDetails, 9, SIGNUP_START_ROW + SPK2_ROW_IDX);
-  setSpeakerCells(toastmasterDetails, 10, SIGNUP_START_ROW + SPK3_ROW_IDX);
+  setSpeakerCells(
+    toastmasterDetails,
+    8,
+    SIGNUP_START_ROW + ROW_MAPPING["speaker1"]
+  );
+  setSpeakerCells(
+    toastmasterDetails,
+    9,
+    SIGNUP_START_ROW + ROW_MAPPING["speaker2"]
+  );
+  setSpeakerCells(
+    toastmasterDetails,
+    10,
+    SIGNUP_START_ROW + ROW_MAPPING["speaker3"]
+  );
 }
 
 function setSpeakerCells(toastmasterDetails, tmDetailsRow, signUpSheetRow) {

--- a/src/CopyToastmasterDetailsToRoles.js
+++ b/src/CopyToastmasterDetailsToRoles.js
@@ -70,19 +70,37 @@ class ToastmasterDetails {
     };
 
     // Fill out meeting metadata (minus already filled-in date)
-    setCell(Meeting_Theme_COL, this.meetingTheme);
-    setCell(Word_of_the_Day_COL, this.wordOfTheDay);
-    setCell(Word_of_the_Day_Part_of_Speech_COL, this.wordOfTheDayPartOfSpeech);
-    setCell(Word_of_the_Day_Definition_COL, this.wordOfTheDayDescription);
+    setCell(ROLES_COL_MAP["Meeting_Theme"], this.meetingTheme);
+    setCell(ROLES_COL_MAP["Word_of_the_Day"], this.wordOfTheDay);
     setCell(
-      Word_of_the_Day_Sample_Sentence_COL,
+      ROLES_COL_MAP["Word_of_the_Day_Part_of_Speech"],
+      this.wordOfTheDayPartOfSpeech
+    );
+    setCell(
+      ROLES_COL_MAP["Word_of_the_Day_Definition"],
+      this.wordOfTheDayDescription
+    );
+    setCell(
+      ROLES_COL_MAP["Word_of_the_Day_Sample_Sentence"],
       this.wordOfTheDaySampleSentence
     );
 
     // Fill out Speaker Details
-    this.speaker1.populateRolesSheet(rolesSheet, roleEntryRow, Speaker_1_COL);
-    this.speaker2.populateRolesSheet(rolesSheet, roleEntryRow, Speaker_2_COL);
-    this.speaker3.populateRolesSheet(rolesSheet, roleEntryRow, Speaker_3_COL);
+    this.speaker1.populateRolesSheet(
+      rolesSheet,
+      roleEntryRow,
+      ROLES_COL_MAP["Speaker_1"]
+    );
+    this.speaker2.populateRolesSheet(
+      rolesSheet,
+      roleEntryRow,
+      ROLES_COL_MAP["Speaker_2"]
+    );
+    this.speaker3.populateRolesSheet(
+      rolesSheet,
+      roleEntryRow,
+      ROLES_COL_MAP["Speaker_3"]
+    );
   }
 }
 

--- a/src/PopulateRolesSheet.js
+++ b/src/PopulateRolesSheet.js
@@ -9,73 +9,79 @@
 // Roles Sheet Column References
 //  Note: some are not currently used
 //  These are 1-indexed relative to the Roles spreadsheet
-var Date_COL = 1;
-var Meeting_Theme_COL = 2;
-var Word_of_the_Day_COL = 3;
-var Word_of_the_Day_Part_of_Speech_COL = 4;
-var Word_of_the_Day_Definition_COL = 5;
-var Word_of_the_Day_Sample_Sentence_COL = 6;
-var Meeting_Location_COL = 7;
-var Sergeant_at_Arms_COL = 8;
-var Secretary_COL = 9;
-var Toastmaster_COL = 10;
-var Jokemaster_COL = 11;
-var General_Evaluator_COL = 12;
-var Recorder_COL = 13;
-var Timer_COL = 14;
-var Ah_Counter_COL = 15;
-var Wordmaster_Grammarian_COL = 16;
-var Table_Topics_Master_COL = 17;
-var Speaker_1_COL = 18;
-var Speaker_1_Pathway_COL = 19;
-var Speaker_1_Level_COL = 20;
-var Speaker_1_Project_COL = 21;
-var Speaker_1_Speech_Title_COL = 22;
-var Speaker_1_Min_Time_COL = 23;
-var Speaker_1_Max_Time_COL = 24;
-var Speaker_2_COL = 25;
-var Speaker_2_Pathway_COL = 26;
-var Speaker_2_Level_COL = 27;
-var Speaker_2_Project_COL = 28;
-var Speaker_2_Speech_Title_COL = 29;
-var Speaker_2_Min_Time_COL = 30;
-var Speaker_2_Max_Time_COL = 31;
-var Speaker_3_COL = 32;
-var Speaker_3_Pathway_COL = 33;
-var Speaker_3_Project_COL = 34;
-var Speaker_3_Level_COL = 35;
-var Speaker_3_Speech_Title_COL = 36;
-var Speaker_3_Min_Time_COL = 37;
-var Speaker_3_Max_Time_COL = 38;
-var Speaker_4_COL = 39;
-var Speaker_4_Pathway_COL = 40;
-var Speaker_4_Project_COL = 41;
-var Speaker_4_Level_COL = 42;
-var Speaker_4_Speech_Title_COL = 43;
-var Speaker_4_Min_Time_COL = 44;
-var Speaker_4_Max_Time_COL = 45;
-var Speaker_5_COL = 46;
-var Speaker_5_Pathway_COL = 47;
-var Speaker_5_Level_COL = 48;
-var Speaker_5_Project_COL = 49;
-var Speaker_5_Speech_Title_COL = 50;
-var Speaker_5_Min_Time_COL = 51;
-var Speaker_5_Max_Time_COL = 52;
-var Evaluator_1_COL = 53;
-var Evaluator_2_COL = 54;
-var Evaluator_3_COL = 55;
-var Evaluator_4_COL = 56;
-var Evaluator_5_COL = 57;
-var Waiting_List_Speaker_1_COL = 58;
-var Waiting_List_Speaker_2_COL = 59;
-var Club_President_COL = 60;
-var VP_Education_COL = 61;
-var VP_Membership_COL = 62;
-var VP_Public_Relations_COL = 63;
-var Club_Secretary_COL = 64;
-var Club_Treasurer_COL = 65;
-var Club_Sergeant_at_Arms_COL = 66;
-var Mentorship_Chair_COL = 67;
+// TODO(acmiyaguchi): add simple check to ensure these are in the correct order
+const ROLES_COL_NAMES = [
+  "Date",
+  "Meeting_Theme",
+  "Word_of_the_Day",
+  "Word_of_the_Day_Part_of_Speech",
+  "Word_of_the_Day_Definition",
+  "Word_of_the_Day_Sample_Sentence",
+  "Meeting_Location",
+  "Sergeant_at_Arms",
+  "Secretary",
+  "Toastmaster",
+  "Jokemaster",
+  "General_Evaluator",
+  "Recorder",
+  "Timer",
+  "Ah_Counter",
+  "Wordmaster_Grammarian",
+  "Table_Topics_Master",
+  "Speaker_1",
+  "Speaker_1_Pathway",
+  "Speaker_1_Level",
+  "Speaker_1_Project",
+  "Speaker_1_Speech_Title",
+  "Speaker_1_Min_Time",
+  "Speaker_1_Max_Time",
+  "Speaker_2",
+  "Speaker_2_Pathway",
+  "Speaker_2_Level",
+  "Speaker_2_Project",
+  "Speaker_2_Speech_Title",
+  "Speaker_2_Min_Time",
+  "Speaker_2_Max_Time",
+  "Speaker_3",
+  "Speaker_3_Pathway",
+  "Speaker_3_Project",
+  "Speaker_3_Level",
+  "Speaker_3_Speech_Title",
+  "Speaker_3_Min_Time",
+  "Speaker_3_Max_Time",
+  "Speaker_4",
+  "Speaker_4_Pathway",
+  "Speaker_4_Project",
+  "Speaker_4_Level",
+  "Speaker_4_Speech_Title",
+  "Speaker_4_Min_Time",
+  "Speaker_4_Max_Time",
+  "Speaker_5",
+  "Speaker_5_Pathway",
+  "Speaker_5_Level",
+  "Speaker_5_Project",
+  "Speaker_5_Speech_Title",
+  "Speaker_5_Min_Time",
+  "Speaker_5_Max_Time",
+  "Evaluator_1",
+  "Evaluator_2",
+  "Evaluator_3",
+  "Evaluator_4",
+  "Evaluator_5",
+  "Waiting_List_Speaker_1",
+  "Waiting_List_Speaker_2",
+  "Club_President",
+  "VP_Education",
+  "VP_Membership",
+  "VP_Public_Relations",
+  "Club_Secretary",
+  "Club_Treasurer",
+  "Club_Sergeant_at_Arms",
+  "Mentorship_Chair",
+];
+const ROLES_COL_MAP = Object.fromEntries(
+  ROLES_COL_NAMES.map((name, index) => [name, index + 1])
+);
 
 // A mapping of the offset for different speaker columns
 var Speaker_COL_OFFSET = 0;
@@ -95,7 +101,9 @@ function getAllRolesDates() {
   var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(
     ROLES_SHEET_NAME
   );
-  return sheet.getRange(1, Date_COL, sheet.getLastRow()).getValues();
+  return sheet
+    .getRange(1, ROLES_COL_MAP["Date"], sheet.getLastRow())
+    .getValues();
 }
 
 // Check if the current entry is within the last few columns
@@ -106,7 +114,11 @@ function getMostRecentRows(rowsToCheck = 10) {
     ROLES_SHEET_NAME
   );
   var lastFilledRow = sheet.getLastRow();
-  return sheet.getRange(lastFilledRow - rowsToCheck + 1, Date_COL, rowsToCheck);
+  return sheet.getRange(
+    lastFilledRow - rowsToCheck + 1,
+    ROLES_COL_MAP["Date"],
+    rowsToCheck
+  );
 }
 
 // Check whether the date of interest is in the spreadsheet's last few rows

--- a/src/PopulateRolesSheet.js
+++ b/src/PopulateRolesSheet.js
@@ -20,6 +20,7 @@ const ROLES_COL_NAMES = [
   "Meeting_Location",
   "Sergeant_at_Arms",
   "Secretary",
+  "Tech_Chair",
   "Toastmaster",
   "Jokemaster",
   "General_Evaluator",

--- a/src/RosterScripts.js
+++ b/src/RosterScripts.js
@@ -114,14 +114,23 @@ function copyOfficersToRoles(dateString) {
   };
 
   // Set Cells for Officers
-  setCell(Club_President_COL, officers[OfficerRole.president]);
-  setCell(VP_Education_COL, officers[OfficerRole.vpEducation]);
-  setCell(VP_Membership_COL, officers[OfficerRole.vpMembership]);
-  setCell(VP_Public_Relations_COL, officers[OfficerRole.vpPublicRelations]);
-  setCell(Club_Secretary_COL, officers[OfficerRole.clubSecretary]);
-  setCell(Club_Treasurer_COL, officers[OfficerRole.clubTreasurer]);
-  setCell(Club_Sergeant_at_Arms_COL, officers[OfficerRole.sergeantAtArms]);
-  setCell(Mentorship_Chair_COL, officers[OfficerRole.chairOfMentorship]);
+  setCell(ROLES_COL_MAP["Club_President"], officers[OfficerRole.president]);
+  setCell(ROLES_COL_MAP["VP_Education"], officers[OfficerRole.vpEducation]);
+  setCell(ROLES_COL_MAP["VP_Membership"], officers[OfficerRole.vpMembership]);
+  setCell(
+    ROLES_COL_MAP["VP_Public_Relations"],
+    officers[OfficerRole.vpPublicRelations]
+  );
+  setCell(ROLES_COL_MAP["Club_Secretary"], officers[OfficerRole.clubSecretary]);
+  setCell(ROLES_COL_MAP["Club_Treasurer"], officers[OfficerRole.clubTreasurer]);
+  setCell(
+    ROLES_COL_MAP["Club_Sergeant_at_Arms"],
+    officers[OfficerRole.sergeantAtArms]
+  );
+  setCell(
+    ROLES_COL_MAP["Mentorship_Chair"],
+    officers[OfficerRole.chairOfMentorship]
+  );
 }
 
 // Function to clear the roster selections

--- a/src/SignUpSheetAdvance.js
+++ b/src/SignUpSheetAdvance.js
@@ -1,5 +1,5 @@
-const __SIGNUP_SHEET_HEADER_ROW_NUM = 7;
-const __SIGNUP_SHEET_SECTION_START_COL_NUM = 2;
+const __SIGNUP_SHEET_HEADER_ROW_NUM = SIGNUP_START_ROW;
+const __SIGNUP_SHEET_SECTION_START_COL_NUM = SIGNUP_START_COL;
 
 function advanceSignUpSheet() {
   var signUpSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(
@@ -40,6 +40,7 @@ function clearOutCurrentSignUp(signUpSheet, signUpTemplate) {
 }
 
 function deleteCurrentSignupSection(signUpSheet, signUpTemplate) {
+  // TODO: remove extra columns if they aren't being used for anything
   signUpSheet.showColumns(5);
   signUpSheet.showColumns(6);
 
@@ -48,8 +49,8 @@ function deleteCurrentSignupSection(signUpSheet, signUpTemplate) {
       __SIGNUP_SHEET_HEADER_ROW_NUM,
       __SIGNUP_SHEET_SECTION_START_COL_NUM,
       signUpTemplate.getLastRow(),
-      signUpTemplate.getLastColumn() + 2
-    ) // with 2 header cols
+      signUpTemplate.getLastColumn()
+    )
     .deleteCells(SpreadsheetApp.Dimension.COLUMNS);
 }
 

--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -36,3 +36,14 @@ function normalizeName(name) {
     .split(/\s+/)
     .join("_");
 }
+
+/// Slice a list based on the location of two entries in the list inclusive.
+/// Throws an exception if the resulting slice is empty. Assumes all entries are
+/// unique.
+function sliceRowsBetweenValues(arr, first, last) {
+  let sliced = arr.slice(arr.indexOf(first), arr.indexOf(last) + 1);
+  if (sliced.length == 0) {
+    throw "sliced list is empty";
+  }
+  return sliced;
+}


### PR DESCRIPTION
This PR adds two major updates for hybrid meetings:

* A new `remote` column, to determine whether the role is going to remote or in-person
* A new `tech chair` row, which is the tentative name for the AV operator in the room

I added the new fields into the sign-up sheet. There are a few things that need to be resolved.

* The sign-up advance truncates the first two columns on the new sheet. I'm not entirely sure how fields are being copied down to the left. As a potentially related tangent, there are hidden columns that are apparently being added, but I don't see them anywhere in our sheet:

https://github.com/Mountain-View-Toastmasters/sign-up-sheet/blob/8c8a292f653fec616e315bbd015c53e8fa84f990/src/SignUpSheetAdvance.js#L56-L72

* A new column needs to be added to the roles sheet for the tech chair. I want to do a similar refactoring where the offsets are enumerated instead of hard-coded.
* The remote/in-person column is not captured in the sign-up sheet, and I'm not sure what representation would be best.

